### PR TITLE
Update peer dependencies to not require exact version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-fullstory-component",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -46,8 +46,8 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "react": "15.4.1",
-    "react-dom": "15.4.1"
+    "react": "^15.4.1",
+    "react-dom": "^15.4.1"
   },
   "optionalDependencies": {
     "fsevents": "*"


### PR DESCRIPTION
This prevents a warning from being fired on install if the versions of the peer
dependencies does not match exactly, which should be fine for this library.

I also updated the version to `2.0.1` so that all you need to do if this is agreeable
to you is to merge and do an `npm publish`. 😄 